### PR TITLE
themeProvider를 이용해 theme 관리하도록 수정

### DIFF
--- a/src/static/const.ts
+++ b/src/static/const.ts
@@ -1,9 +1,0 @@
-export enum ColorList {
-    default = '#edf0f5',
-    primary = '#2e78f7',
-    secondary = '#5c5c5c',
-}
-export enum TextColor {
-    gray1 = '#f0f2f4',
-    darkgray1 = '#5c5c5c',
-}

--- a/src/static/styled-components.ts
+++ b/src/static/styled-components.ts
@@ -1,0 +1,14 @@
+import * as styledComponents from 'styled-components';
+import { ThemedStyledComponentsModule } from 'styled-components';
+import { StyleClosetTheme } from './theme';
+
+const {
+    default: styled,
+    css,
+    createGlobalStyle,
+    keyframes,
+    ThemeProvider,
+} = styledComponents as ThemedStyledComponentsModule<StyleClosetTheme>;
+
+export { css, createGlobalStyle, keyframes, ThemeProvider };
+export default styled;

--- a/src/static/theme.ts
+++ b/src/static/theme.ts
@@ -1,0 +1,25 @@
+const colors = {
+  white: '#ffffff',
+  blue: '#0077ff',
+  grays: ['#eff0f5', '#dcdcde', '#a2a2a2', '#646464', '#585858'],
+  blacks: ['#2c2c2c', '#363636'],
+};
+const breakpoints = ['31.25em', '43.75em', '46.875em'];
+const fontSizes = ['1.2rem', '1.4rem', '1.6rem', '1.8rem', '2.4rem', '2.8rem', '3.2rem', '4.0rem', '4.8rem', '6.4rem'];
+const space = ['0', '.4rem', '.8rem', '1.2rem', '1.6rem', '2.0rem', '3.2rem', '4.8rem', '6.4rem', '9.6rem'];
+
+export interface StyleClosetTheme {
+  breakpoints: string[];
+  fontSizes: string[];
+  space: string[];
+  colors: { [key in keyof typeof colors]: string | string[] };
+}
+
+const theme: StyleClosetTheme = {
+  breakpoints,
+  fontSizes,
+  space,
+  colors,
+};
+
+export { theme };

--- a/src/static/themeDecorator.tsx
+++ b/src/static/themeDecorator.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from './theme';
+
+export const ThemeDecorator = (storyFn: () => JSX.Element) => (
+  <ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>
+);


### PR DESCRIPTION
color, fontsize, space와 같은 것들을 themeProvider를 이용해 공통적으로 관리하도록 수정

theme.colors.grays[0]이나, theme.colors.blue와 같이 사용 할 수 있다. 배열로 되어있는 색상은 숫자가 작아질 수록 밝은 색이고, 크기가 커질수록 어두운 색이다.