### PR TITLE
storybook 형식 변경

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -1,8 +1,2 @@
 import { configure } from '@storybook/react';
-import requireContext from 'require-context.macro';
-
-const req = requireContext('../src', true, /\.stories\.tsx$/);
-function loadStories() {
-    req.keys().forEach(req);
-}
-configure(loadStories, module);
+configure(require.context('../src', true, /\.stories\.tsx$/), module);

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,61 +1,66 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { select, withKnobs } from '@storybook/addon-knobs';
 import { theme } from '../../static/theme';
 import { ThemeDecorator } from '../../static/themeDecorator';
 import Button from './index';
 
-storiesOf('Button', module)
-    .addDecorator(withKnobs)
-    .addDecorator(ThemeDecorator)
-    .add('size',
-        () => <Button
-            size={select('size', {
-                small: 'small',
-                medium: 'medium',
-                large: 'large',
-            }, 'medium')}>
-            text1</Button>
-    )
-    .add('variant',
-        () => <Button
-            color={theme.colors.blue}
-            variant={select('variant', {
-                text: 'text',
-                outlined: 'outlined',
-                contained: 'contained',
-            }, 'outlined')}>
-            text1</Button>
-    )
-    .add('corner',
-        () => <Button
-            color={theme.colors.blue}
-            corner={select('corner', {
-                default: 'default',
-                rounded: 'rounded',
-            }, 'default')}>
-            text11</Button>
-    )
-    .add('mix',
-        () => <Button
-            color={select('color', {
-                paleGray: theme.colors.g100,
-                blue: theme.colors.blue,
-                grayishBrown: theme.colors.g300,
-            }, theme.colors.blue)}
-            corner={select('corner', {
-                default: 'default',
-                rounded: 'rounded',
-            }, 'rounded')}
-            variant={select('variant', {
-                text: 'text',
-                outlined: 'outlined',
-                contained: 'contained',
-            }, 'contained')}
-            size={select('size', {
-                small: 'small',
-                medium: 'medium',
-                large: 'large',
-            }, 'medium')}>
-            text1</Button>
-    );
+export default {
+    title: 'components|atomic/Button', // 스토리북에서 보여질 그룹과 경로를 명시
+    component: Button, // 어떤 컴포넌트를 문서화 할지 명시
+    decorators: [withKnobs, ThemeDecorator], // 애드온 적용
+};
+
+export const button = () => {
+    const size = select('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+    }, 'medium');
+    return <Button size={size}>button</Button>;
+};
+button.story = {
+    name: 'Default',
+};
+
+export const variantAttr = () => {
+    const variant = select('variant', {
+        text: 'text',
+        outlined: 'outlined',
+        contained: 'contained',
+    }, 'outlined');
+    return <Button color={theme.colors.blue} variant={variant}>variant btn</Button>;
+};
+export const cornerAttr = () => {
+    const corner = select('corner', {
+        default: 'default',
+        rounded: 'rounded',
+    }, 'default');
+    return <Button color={theme.colors.blue} corner={corner}>corner btn</Button>;
+};
+export const mix = () => {
+    const color = select('color', {
+        paleGray: theme.colors.g100,
+        blue: theme.colors.blue,
+        grayishBrown: theme.colors.g300,
+    }, theme.colors.blue);
+    const corner = select('corner', {
+        default: 'default',
+        rounded: 'rounded',
+    }, 'rounded');
+    const variant = select('variant', {
+        text: 'text',
+        outlined: 'outlined',
+        contained: 'contained',
+    }, 'contained');
+    const size = select('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+    }, 'medium');
+    return <Button
+        color={color}
+        corner={corner}
+        variant={variant}
+        size={size}>mix btn
+    </Button>;
+};

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import classnames from 'classnames';
-import styles from './button.module.scss';
 import { css } from 'styled-components';
 import styled from '../../static/styled-components';
+import { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
 
 export interface ButtonProps {
   type: 'button' | 'reset' | 'submit';
@@ -16,25 +16,22 @@ export interface ButtonProps {
   color: string;
 }
 
-const BaseButton = (props: ButtonProps): React.ReactElement<ButtonProps> => {
-  const { type, onClick, children, className, disabled } = props;
-  const classProps: string = classnames(
-    {
-      [styles.disabled]: disabled,
-    },
-    className
-  );
+const Button = (props: ButtonProps): React.ReactElement<ButtonProps> => {
+  const {
+    type,
+    corner,
+    size,
+    variant,
+    onClick,
+    children,
+    className,
+    disabled,
+    color,
+  } = props;
+  const themeContext = useContext(ThemeContext);
+  const theme = themeContext;
 
-  return (
-    <button type={type} onClick={onClick} disabled={disabled} className={classProps}>
-      {children}
-    </button>
-  );
-};
-
-const Button = styled(BaseButton)((themeProps) => {
-  const { theme, size, variant, color, corner } = themeProps;
-  const StyleButton = css`
+  const StyleButton = styled.button`
     background: transparent;
     border-radius: 4px;
     color: ${theme.colors.g500};
@@ -64,7 +61,7 @@ const Button = styled(BaseButton)((themeProps) => {
     min-width: 90px;
     `}
 
-    ${variant === 'contained' && color === 'default' && css`
+    ${variant === 'contained' && color === theme.colors.g100 && css`
       color: ${theme.colors.g500};
       background: ${color};
       border: 1px solid ${color};
@@ -74,15 +71,19 @@ const Button = styled(BaseButton)((themeProps) => {
     font-size: 0.85rem;
     `}
   `;
-  return StyleButton;
-});
+  return (
+    <StyleButton type={type} onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </StyleButton>
+  );
+};
 
-BaseButton.defaultProps = {
+Button.defaultProps = {
   type: 'button',
   corner: 'default',
   size: 'medium',
   onClick: () => {},
-  className: null,
+  className: '',
   disabled: false,
   variant: 'contain',
   color: 'black',

--- a/src/components/icon/icon.stories.tsx
+++ b/src/components/icon/icon.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import { ReactComponent as DelIc } from '../../assets/icons/cross.svg';
 import { ReactComponent as SearchIc } from '../../assets/icons/search.svg';
@@ -8,24 +7,31 @@ import { theme } from '../../static/theme';
 import Icon from './index';
 import Button from '../button';
 
-storiesOf('Icon', module)
-    .addDecorator(withKnobs)
-    .addDecorator(ThemeDecorator)
-    .add('icon only',
-        () => <Icon
-            size={select('size', {
-                small: 'small',
-                medium: 'medium',
-                large: 'large',
-            }, 'medium')}>
-            <SearchIc></SearchIc>
+export default {
+    title: 'components|atomic/Icon',
+    component: Icon,
+    decorators: [withKnobs, ThemeDecorator],
+};
+
+export const icon = () => {
+    const size = select('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+    }, 'medium');
+    return <Icon size={size}>
+        <SearchIc></SearchIc>
+    </Icon>;
+};
+icon.story = {
+    name: 'Default',
+};
+
+export const iconWithButton = () => {
+    return <Button corner='rounded' variant='contained' color={theme.colors.blue}>
+        <span>향하다</span>
+        <Icon size='small'>
+            <DelIc></DelIc>
         </Icon>
-    )
-    .add('icon with button',
-        () => <Button corner='rounded' variant='contained' color={theme.colors.blue}>
-            <span>향하다</span>
-            <Icon size='small'>
-                <DelIc></DelIc>
-            </Icon>
-        </Button>
-    );
+    </Button>;
+};

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-export interface ButtonProps {
+export interface IconProps {
     children: React.ReactNode;
     size: 'small' | 'medium' | 'large';
+    className: string;
 }
 
-const Icon = (props: ButtonProps): React.ReactElement<ButtonProps> => {
-    const { children, size } = props;
+const Icon = (props: IconProps): React.ReactElement<IconProps> => {
+    const {
+        children,
+        size,
+        className,
+    } = props;
+
     const StyleSpan = styled.span`
         svg {
             width: 20px;
@@ -29,12 +35,13 @@ const Icon = (props: ButtonProps): React.ReactElement<ButtonProps> => {
     `;
 
     return (
-        <StyleSpan>{children}</StyleSpan>
+        <StyleSpan className={className}>{children}</StyleSpan>
     );
 };
 
 Icon.defaultProps = {
     size: 'medium',
+    className: '',
 };
 
 export default Icon;

--- a/src/components/label/index.tsx
+++ b/src/components/label/index.tsx
@@ -6,10 +6,18 @@ export interface LabelProps {
     color: string;
     size: 'medium' | 'large' | string;
     weight: 'light' | 'normal' | 'semi' | 'bold';
+    className: string;
 }
 
 const Label = (props: LabelProps): React.ReactElement<LabelProps> => {
-    const { children, size, color, weight } = props;
+    const {
+        children,
+        size,
+        color,
+        weight,
+        className,
+    } = props;
+
     const StyleDiv = styled.div`
         font-weight: normal;
         color: ${color};
@@ -36,7 +44,7 @@ const Label = (props: LabelProps): React.ReactElement<LabelProps> => {
     `;
 
     return (
-        <StyleDiv>{children}</StyleDiv>
+        <StyleDiv className={className}>{children}</StyleDiv>
     );
 };
 
@@ -44,6 +52,7 @@ Label.defaultProps = {
     size: 'medium',
     color: 'black',
     weight: 'normal',
+    className: '',
 };
 
 export default Label;

--- a/src/components/label/label.stories.tsx
+++ b/src/components/label/label.stories.tsx
@@ -1,39 +1,46 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { withKnobs, select, text } from '@storybook/addon-knobs';
 import { theme } from '../../static/theme';
 import Label from './index';
 
-storiesOf('Label', module)
-    .addDecorator(withKnobs)
-    .add('large label',
-        () => <Label
-            color={select('color', {
-                blackTwo: theme.colors.b100,
-                deepSkyBlue: theme.colors.blue,
-            }, 'black-two')}
-            weight={select('weight', {
-                light: 'light',
-                normal: 'normal',
-                semi: 'semi',
-                bold: 'bold',
-            }, 'bold')}
-            size='large'>필터링</Label>
-    )
-    .add('medium label',
-        () => <Label size='medium'>결과 내 재검색</Label>
-    )
-    .add('custom label',
-        () => <Label
-            color={select('color', {
-                grayishBrown: theme.colors.g300,
-                lightGray: theme.colors.g100,
-            }, theme.colors.g300)}
-            weight={select('weight', {
-                light: 'light',
-                normal: 'normal',
-                semi: 'semi',
-                bold: 'bold',
-            }, 'light')}
-            size={text('size', '13px')}>[동사] 어떤 목표로 뜻이 쏠리어 향하다.</Label>
-    );
+export default {
+    title: 'components|atomic/Label',
+    component: Label,
+    decorators: [withKnobs],
+};
+
+export const label = () => {
+    const color = select('color', {
+        blackTwo: theme.colors.b100,
+        deepSkyBlue: theme.colors.blue,
+    }, 'black-two');
+    const weight = select('weight', {
+        light: 'light',
+        normal: 'normal',
+        semi: 'semi',
+        bold: 'bold',
+    }, 'bold');
+    return <Label color={color} weight={weight} size='large'>필터링</Label>;
+};
+label.story = {
+    name: 'Default',
+};
+
+export const medium = () => <Label size='medium'>결과 내 재검색</Label>;
+
+export const custom = () => {
+    const color = select('color', {
+        grayishBrown: theme.colors.g300,
+        lightGray: theme.colors.g100,
+    }, theme.colors.g300);
+    const weight = select('weight', {
+        light: 'light',
+        normal: 'normal',
+        semi: 'semi',
+        bold: 'bold',
+    }, 'light');
+    const size = text('size', '13px');
+    return <Label color={color} weight={weight} size={size}>
+        [동사] 어떤 목표로 뜻이 쏠리어 향하다.
+    </Label>;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import Root from './routes/index';
 import * as serviceWorker from './serviceWorker';
+import { ThemeProvider } from 'styled-components';
+import { theme } from './static/theme';
 
-ReactDOM.render(<Root />, document.getElementById('root'));
+ReactDOM.render(
+    <ThemeProvider theme={theme}>
+        <Root />
+    </ThemeProvider>
+, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
-import { ThemeProvider } from 'styled-components';
-import { theme } from '../static/theme';
 import Button from '../components/button';
 
 const HomePage: React.FC<RouteComponentProps> = (props) => {
@@ -11,12 +9,12 @@ const HomePage: React.FC<RouteComponentProps> = (props) => {
     props.history.push(url);
   }
   return (
-    <ThemeProvider theme={theme}>
+    <>
       <form>
         <input />
         <Button onClick={searchWord}>검색</Button>
       </form>
-    </ThemeProvider>
+    </>
   );
 };
 


### PR DESCRIPTION
카드 컴포넌트 만들다가 수정 사항이 너무 길어지는 것 같아서 한 번 pr 끊고 가려고 합니다
최신버전의 Storybook에서는 API 말고 CSF(Component Story Format) 형식이 훨씬 깔끔하고 편하기 때문에 CSF 형식으로 작성되는 것이 권장됩니다. 
[component-story-format](https://storybook.js.org/docs/formats/component-story-format/)

API 형식 예제
```
import React from 'react';
import { storiesOf } from '@storybook/react';
import { action } from '@storybook/addon-actions';
import Button from '../components/Button';

storiesOf('Button', module)
  .add('with text', () => (
    <Button onClick={action('clicked')}>Hello Button</Button>
  ))
  .add('with some emoji', () => (
    <Button onClick={action('clicked')}>
      <span role="img" aria-label="so cool">
        😀 😎 👍 💯
      </span>
    </Button>
  ));
```

CSF 형식 예제
```
import React from 'react';
import Hello from './Hello';

export default {
  title: 'components|basic/Hello', // 스토리북에서 보여질 그룹과 경로를 명시
  component: Hello // 어떤 컴포넌트를 문서화 할지 명시
};

export const standard = () => <Hello name="Storybook" />;
export const big = () => <Hello name="Storybook" big />;
```