### PR TITLE
IconButton component 추가

### DIFF
--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -41,7 +41,7 @@ export const mix = () => {
     const color = select('color', {
         paleGray: theme.colors.g100,
         blue: theme.colors.blue,
-        grayishBrown: theme.colors.g300,
+        grayishBrown: theme.colors.g500,
     }, theme.colors.blue);
     const corner = select('corner', {
         default: 'default',

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -55,7 +55,7 @@ const Button = (props: ButtonProps): React.ReactElement<ButtonProps> => {
 
     ${variant === 'outlined' && css`
       color: ${color};
-      border: 1px solid ${color};
+      border: 1px solid ${color === theme.colors.g500 ? theme.colors.g200 : color};
     `}
 
     ${corner === 'rounded' && css`

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -11,7 +11,7 @@ export interface ButtonProps {
   variant: 'text' | 'outlined' | 'contained';
   onClick: () => void;
   children?: React.ReactNode;
-  className: string;
+  className?: string;
   disabled: boolean;
   color: string;
 }
@@ -84,7 +84,6 @@ Button.defaultProps = {
   corner: 'default',
   size: 'medium',
   onClick: () => {},
-  className: '',
   disabled: false,
   variant: 'contain',
   color: 'black',

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -10,7 +10,7 @@ export interface ButtonProps {
   size: 'small' | 'medium' | 'large';
   variant: 'text' | 'outlined' | 'contained';
   onClick: () => void;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className: string;
   disabled: boolean;
   color: string;
@@ -30,17 +30,19 @@ const Button = (props: ButtonProps): React.ReactElement<ButtonProps> => {
   } = props;
   const themeContext = useContext(ThemeContext);
   const theme = themeContext;
-
+  const fontSize = (!size || size === 'medium') ? 1.1 : (size === 'small' ? 0.8 : 1.8);
   const StyleButton = styled.button`
     background: transparent;
     border-radius: 4px;
     color: ${theme.colors.g500};
-    padding: 6px 16px;
-    min-width: 64px;
+    padding: 6px 14px;
+    min-width: 70px;
     letter-spacing: -0.9px;
     font-weight: 500;
-    font-size: 1.1em;
-
+    font-size: ${fontSize + 'em'};
+    pointer-events: ${disabled ? 'none' : 'auto'};
+    cursor: pointer;
+    outline: 0;
     ${variant === 'text' && css`
     border: 0;
     `}
@@ -52,13 +54,12 @@ const Button = (props: ButtonProps): React.ReactElement<ButtonProps> => {
     `}
 
     ${variant === 'outlined' && css`
-    color: ${color};
-    border: 1px solid ${color};
+      color: ${color};
+      border: 1px solid ${color};
     `}
 
     ${corner === 'rounded' && css`
-    border-radius: 20px;
-    min-width: 90px;
+      border-radius: ${fontSize * 1.25 + 'rem'};
     `}
 
     ${variant === 'contained' && color === theme.colors.g100 && css`
@@ -68,7 +69,7 @@ const Button = (props: ButtonProps): React.ReactElement<ButtonProps> => {
     `}
 
     ${size === 'small' && css`
-    font-size: 0.85rem;
+      min-width: 90px;
     `}
   `;
   return (

--- a/src/components/icon/icon.stories.tsx
+++ b/src/components/icon/icon.stories.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { withKnobs, select } from '@storybook/addon-knobs';
-import { ReactComponent as DelIc } from '../../assets/icons/cross.svg';
 import { ReactComponent as SearchIc } from '../../assets/icons/search.svg';
 import { ThemeDecorator } from '../../static/themeDecorator';
-import { theme } from '../../static/theme';
 import Icon from './index';
-import Button from '../button';
 
 export default {
     title: 'components|atomic/Icon',
@@ -25,13 +22,4 @@ export const icon = () => {
 };
 icon.story = {
     name: 'Default',
-};
-
-export const iconWithButton = () => {
-    return <Button corner='rounded' variant='contained' color={theme.colors.blue}>
-        <span>향하다</span>
-        <Icon size='small'>
-            <DelIc></DelIc>
-        </Icon>
-    </Button>;
 };

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -5,6 +5,7 @@ export interface IconProps {
     children: React.ReactNode;
     size: 'small' | 'medium' | 'large';
     className: string;
+    color: string;
 }
 
 const Icon = (props: IconProps): React.ReactElement<IconProps> => {
@@ -12,25 +13,18 @@ const Icon = (props: IconProps): React.ReactElement<IconProps> => {
         children,
         size,
         className,
+        color,
     } = props;
-
+    const fontSize = (!size || size === 'medium') ? 1.1 : (size === 'small' ? 0.8 : 1.8);
     const StyleSpan = styled.span`
+        width: 1em;
+        height: 100%;
+        font-size: ${fontSize + 'em'};
+        display: flex;
         svg {
-            width: 20px;
-            height: 20px;
-            mask-size: contain;
-            mask-position: 50% 50%;
-            mask-repeat: no-repeat;
-
-            ${size === 'small' && css`
-                width: 12px;
-                height: 12px;
-            `}
-
-            ${size === 'large' && css`
-                width: 28px;
-                height: 28px;
-            `}
+            width: 100%;
+            height: 100%;
+            fill: ${color};
         }
     `;
 

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 export interface IconProps {
     children: React.ReactNode;
     size: 'small' | 'medium' | 'large';
-    className: string;
+    className?: string;
     color: string;
 }
 
@@ -35,7 +35,6 @@ const Icon = (props: IconProps): React.ReactElement<IconProps> => {
 
 Icon.defaultProps = {
     size: 'medium',
-    className: '',
 };
 
 export default Icon;

--- a/src/components/iconButton/iconButton.stories.tsx
+++ b/src/components/iconButton/iconButton.stories.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { withKnobs, select, boolean } from '@storybook/addon-knobs';
+import { ReactComponent as DelIc } from '../../assets/icons/cross.svg';
+import { ThemeDecorator } from '../../static/themeDecorator';
+import { theme } from '../../static/theme';
+import IconButton from './index';
+
+export default {
+    title: 'components|atomic/IconButton',
+    component: IconButton,
+    decorators: [withKnobs, ThemeDecorator],
+};
+
+export const icon = () => {
+    const color = select('color', {
+        paleGray: theme.colors.g100,
+        blue: theme.colors.blue,
+        grayishBrown: theme.colors.g500,
+    }, theme.colors.blue);
+    const corner = select('corner', {
+        default: 'default',
+        rounded: 'rounded',
+    }, 'rounded');
+    const variant = select('variant', {
+        text: 'text',
+        outlined: 'outlined',
+        contained: 'contained',
+    }, 'contained');
+    const size = select('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+    }, 'medium');
+    const left = boolean('left', false);
+    return <IconButton icon={<DelIc/>}
+        color={color}
+        corner={corner}
+        variant={variant}
+        size={size}
+        left={left}><span>쫒다</span>
+    </IconButton>;
+};
+icon.story = {
+    name: 'Default',
+};
+
+export const buttonInnerIcon = () => {
+    const color = select('color', {
+        paleGray: theme.colors.g100,
+        blue: theme.colors.blue,
+        grayishBrown: theme.colors.g300,
+    }, theme.colors.blue);
+    const variant = select('variant', {
+        text: 'text',
+        outlined: 'outlined',
+        contained: 'contained',
+    }, 'outlined');
+    const size = select('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+    }, 'medium');
+    return <IconButton icon={<DelIc/>}
+        color={color}
+        variant={variant}
+        corner='rounded'
+        btnInnerIc={true}
+        size={size}>
+    </IconButton>;
+};
+
+export const iconOnly = () => {
+    const color = select('color', {
+        paleGray: theme.colors.g100,
+        blue: theme.colors.blue,
+        grayishBrown: theme.colors.g300,
+    }, theme.colors.blue);
+    const size = select('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+    }, 'medium');
+    return <IconButton icon={<DelIc/>}
+        color={color}
+        variant='text'
+        size={size}>
+    </IconButton>;
+};

--- a/src/components/iconButton/index.tsx
+++ b/src/components/iconButton/index.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import Icon from '../icon';
+import Button, { ButtonProps } from '../button';
+import { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+
+export interface IconButtonProps extends ButtonProps {
+    left: boolean;
+    icon: object;
+    btnInnerIc: boolean;
+}
+
+const IconButton = (props: IconButtonProps): React.ReactElement<IconButtonProps> => {
+    const {
+        children,
+        left,
+        icon,
+        color,
+        variant,
+        btnInnerIc,
+    } = props;
+    const theme = useContext(ThemeContext);
+
+    let icColor: string;
+    if (variant === 'contained' && color === theme.colors.g100) {
+        icColor = theme.colors.g500;
+    } else if (variant === 'contained') {
+        icColor = theme.colors.g100;
+    } else {
+        icColor = color;
+    }
+    const StyleButton = styled(Button)`
+        align-items: center;
+        display: flex;
+        .label_wrapp {
+            width: 100%;
+            justify-content: inherit;
+            display: inherit;
+            align-items: inherit;
+            position: relative;
+            .ic_wrapp {
+                width: 100%;
+                position: absolute;
+            }
+            .text_wrapp {
+                flex: 1;
+            }
+        }
+        ${!children && !btnInnerIc && css`
+            min-width: auto !important;
+            padding: 12px !important;
+        `}
+    `;
+
+    const StyleIc = styled(Icon)`
+        margin: 0 auto;
+        ${!btnInnerIc && children && css`
+            ${left && css`
+                padding-right: 8px;
+            `}
+            ${!left && css`
+                padding-left: 8px;
+            `}
+        `}
+    `;
+    const ic = <StyleIc size='small' color={icColor}>{icon}</StyleIc>;
+    const iconEl = (btnInnerIc ? <div className='ic_wrapp'>{ic}</div> : ic);
+    return (
+        <StyleButton {...props}>
+            <div className='label_wrapp'>
+                {left && iconEl}
+                <div className='text_wrapp'>
+                    {btnInnerIc ? <br /> : children}
+                </div>
+                {left || iconEl}
+            </div>
+        </StyleButton>
+    );
+};
+
+IconButton.defaultProps = {
+    type: 'button',
+    corner: 'default',
+    size: 'medium',
+    onClick: () => {},
+    className: null,
+    disabled: false,
+    variant: 'contain',
+    color: 'black',
+    left: false,
+    btnInnerIc: false,
+};
+
+export default IconButton;

--- a/src/components/iconButton/index.tsx
+++ b/src/components/iconButton/index.tsx
@@ -84,7 +84,6 @@ IconButton.defaultProps = {
     corner: 'default',
     size: 'medium',
     onClick: () => {},
-    className: null,
     disabled: false,
     variant: 'contain',
     color: 'black',

--- a/src/components/label/index.tsx
+++ b/src/components/label/index.tsx
@@ -6,7 +6,7 @@ export interface LabelProps {
     color: string;
     size: 'medium' | 'large' | string;
     weight: 'light' | 'normal' | 'semi' | 'bold';
-    className: string;
+    className?: string;
 }
 
 const Label = (props: LabelProps): React.ReactElement<LabelProps> => {
@@ -52,7 +52,6 @@ Label.defaultProps = {
     size: 'medium',
     color: 'black',
     weight: 'normal',
-    className: '',
 };
 
 export default Label;


### PR DESCRIPTION
기존 button 컴포넌트를 기반으로 button 안에 icon을 같이 사용할 수 있는 icon button component 생성
<img width="33" alt="스크린샷 2020-02-08 오전 4 08 57" src="https://user-images.githubusercontent.com/26711037/74058757-133bf600-4a2a-11ea-867e-f00b8c1180a8.png">

- icon만 단독으로 있는 경우<br><br>

<img width="87" alt="스크린샷 2020-02-08 오전 3 58 00" src="https://user-images.githubusercontent.com/26711037/74058760-146d2300-4a2a-11ea-8f74-2cd2d9a6da66.png">

- button 안에 icon이 있는 경우<br><br>

<img width="92" alt="스크린샷 2020-02-08 오전 3 01 53" src="https://user-images.githubusercontent.com/26711037/74058764-1505b980-4a2a-11ea-8424-6d1816c31cc7.png">
<img width="98" alt="스크린샷 2020-02-08 오전 3 00 56" src="https://user-images.githubusercontent.com/26711037/74058766-159e5000-4a2a-11ea-81c0-56b9f0e34e7e.png">

- button 안에 text와 icon이 있는 경우<br><br>

<img width="99" alt="스크린샷 2020-02-08 오전 4 21 13" src="https://user-images.githubusercontent.com/26711037/74058951-7463c980-4a2a-11ea-902c-91116dcb2c07.png">

- button 안에 text와 icon이 있는 경우 (icon이 text 왼쪽에 있는 경우)<br>
