### PR TITLE
autosizeInput & autosizeButton 컴포넌트 추가

### DIFF
--- a/src/components/autosizeButton/index.tsx
+++ b/src/components/autosizeButton/index.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react';
+import styled, { ThemeContext } from 'styled-components';
+import IconButton from '../iconButton';
+import AutosizeInput, { AutosizeInputProps } from '../autosizeInput';
+import { ReactComponent as CloseIc } from '../../assets/icons/cross.svg';
+
+export interface AutosizeButtonProps extends AutosizeInputProps {
+    onCancle?: () => void;
+}
+const AutosizeButton = (props: AutosizeButtonProps): React.ReactElement<AutosizeButtonProps> => {
+    const {
+        className,
+        onCancle,
+        ...other
+    } = props;
+    const theme = useContext(ThemeContext);
+
+    const AutosizeInputWrapp = styled.div`
+        display: inline-block;
+        padding: 6px 14px;
+        background: ${theme.colors.g100};
+        border-radius: 30px;
+        position: relative;
+        width: fit-content;
+        align-items: center;
+        .content_wrapp {
+            display: flex;
+        }
+    `;
+
+    return (
+        <AutosizeInputWrapp className={className}>
+            <div className='content_wrapp'>
+                <AutosizeInput {...other} />
+                <IconButton
+                    onClick={onCancle}
+                    icon={<CloseIc />}
+                    variant='text'
+                    size='small'
+                    color={theme.colors.blue}
+                    padding='0px 0px 0px 6px'
+                />
+            </div>
+        </AutosizeInputWrapp >
+    );
+};
+
+AutosizeButton.defaultProps = {
+    color: 'black',
+    type: 'text',
+    minWidth: 1,
+    maxLength: 17,
+    onChange: () => {},
+};
+
+export default AutosizeButton;

--- a/src/components/autosizeButton/index.tsx
+++ b/src/components/autosizeButton/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import IconButton from '../iconButton';
 import AutosizeInput, { AutosizeInputProps } from '../autosizeInput';
-import { ReactComponent as CloseIc } from '../../assets/icons/cross.svg';
+import { ReactComponent as CloseIcon } from '../../assets/icons/cross.svg';
 
 export interface AutosizeButtonProps extends AutosizeInputProps {
     onCancle?: () => void;
@@ -32,24 +32,28 @@ const AutosizeButton = (props: AutosizeButtonProps): React.ReactElement<Autosize
         <AutosizeInputWrapp className={className}>
             <div className='content_wrapp'>
                 <AutosizeInput {...other} />
-                <IconButton
+                <CloseButton
                     onClick={onCancle}
-                    icon={<CloseIc />}
+                    icon={<CloseIcon />}
                     variant='text'
                     size='small'
                     color={theme.colors.blue}
-                    padding='0px 0px 0px 6px'
                 />
             </div>
         </AutosizeInputWrapp >
     );
 };
 
+const CloseButton = styled(IconButton)`
+    padding: 0px 0px 0px 6px !important;
+`;
+
 AutosizeButton.defaultProps = {
     color: 'black',
     type: 'text',
     minWidth: 1,
     maxLength: 17,
+    autoFocus: true,
     onChange: () => {},
 };
 

--- a/src/components/autosizeInput/index.tsx
+++ b/src/components/autosizeInput/index.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, ChangeEvent, FocusEvent, KeyboardEvent } from 'react';
+import styled, { css } from 'styled-components';
+import useAutosizeInput from '../../hooks/useAutosizeInput';
+export interface AutosizeInputProps {
+    type: 'text';
+    maxLength: number;
+    minWidth: number;
+    className?: string;
+    placeholder?: string;
+    label?: string;
+    color?: string;
+    disabled?: boolean;
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+    onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+const BaseInput = (props: AutosizeInputProps): React.ReactElement<AutosizeInputProps> => {
+    const {
+        className,
+        placeholder,
+        minWidth,
+        onChange,
+        ...other
+    } = props;
+    const { AutosizeInputState, onChangeValue, onChangeWidth } = useAutosizeInput();
+    let sizerEle: HTMLSpanElement | null;
+    let placeHolderSizer: HTMLSpanElement | null;
+    let newInputWidth: number;
+
+    const resizeInput = (e: ChangeEvent<HTMLInputElement>) => {
+        onChange(e);
+        if (!sizerEle || typeof sizerEle.scrollWidth === 'undefined') {
+            return;
+        }
+        const changeValue = e.target.value;
+        onChangeValue(changeValue);
+    };
+
+    const updateInputWidth = () => {
+        if (!sizerEle) {
+            return;
+        } else if (placeHolderSizer && !AutosizeInputState.value) {
+            newInputWidth = Math.max(sizerEle.scrollWidth, placeHolderSizer.scrollWidth) + 2;
+        } else {
+            newInputWidth = sizerEle.scrollWidth + 2;
+        }
+        if (newInputWidth <= minWidth) {
+            newInputWidth = minWidth;
+        }
+        onChangeWidth(newInputWidth);
+    };
+
+    useEffect(() => updateInputWidth(), [AutosizeInputState.value]);
+
+    const HiddenText = styled.span`
+        position: absolute;
+        overflow: scroll;
+        white-space: pre;
+        letter-spacing: -0.9px;
+        font-weight: 500;
+        font-size: 1.1em;
+        white-space: pre;
+        display: block;
+        visibility: hidden;
+    `;
+    const dynamicStyle = {
+        width: `${AutosizeInputState.inputWidth}px`,
+    };
+
+    return (
+        <div className={className}>
+            <input
+                onChange={(e) => resizeInput(e)}
+                style={dynamicStyle}
+                value={AutosizeInputState.value}
+                placeholder={placeholder}
+                {...other}
+                autoFocus
+            />
+            <HiddenText ref={(ref) => { sizerEle = ref; }}>
+                {AutosizeInputState.value}
+            </HiddenText>
+            {
+                placeholder
+                && (
+                    <HiddenText ref={(ref) => { placeHolderSizer = ref; }}>
+                        {placeholder}
+                    </HiddenText>
+                )
+            }
+        </div>
+    );
+};
+
+const AutosizeInput = styled(BaseInput)((props) => {
+    const { color } = props;
+    const StyleButton = css`
+        display: inline-block;
+        position: relative;
+        display: flex;
+        width: fit-content;
+        align-items: center;
+        input {
+            box-sizing: content-box;
+            white-space: pre;
+            letter-spacing: -0.9px;
+            font-weight: 500;
+            font-size: 1.1em;
+            border: none;
+            color: ${color};
+            caret-color: ${color};
+            outline: none;
+            background: transparent;
+        }
+  `;
+
+    return StyleButton;
+});
+
+BaseInput.defaultProps = {
+    color: 'black',
+    type: 'text',
+    minWidth: 1,
+    maxLength: 17,
+    onChange: () => {},
+};
+
+export default AutosizeInput;

--- a/src/components/autosizeInput/index.tsx
+++ b/src/components/autosizeInput/index.tsx
@@ -9,6 +9,7 @@ export interface AutosizeInputProps {
     placeholder?: string;
     label?: string;
     color?: string;
+    autoFocus: boolean;
     disabled?: boolean;
     onChange: (e: ChangeEvent<HTMLInputElement>) => void;
     onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
@@ -25,10 +26,8 @@ const BaseInput = (props: AutosizeInputProps): React.ReactElement<AutosizeInputP
     const { AutosizeInputState, onChangeValue, onChangeWidth } = useAutosizeInput();
     let sizerEle: HTMLSpanElement | null;
     let placeHolderSizer: HTMLSpanElement | null;
-    let newInputWidth: number;
 
     const resizeInput = (e: ChangeEvent<HTMLInputElement>) => {
-        onChange(e);
         if (!sizerEle || typeof sizerEle.scrollWidth === 'undefined') {
             return;
         }
@@ -36,7 +35,8 @@ const BaseInput = (props: AutosizeInputProps): React.ReactElement<AutosizeInputP
         onChangeValue(changeValue);
     };
 
-    const updateInputWidth = () => {
+    useEffect(() => {
+        let newInputWidth: number;
         if (!sizerEle) {
             return;
         } else if (placeHolderSizer && !AutosizeInputState.value) {
@@ -48,9 +48,8 @@ const BaseInput = (props: AutosizeInputProps): React.ReactElement<AutosizeInputP
             newInputWidth = minWidth;
         }
         onChangeWidth(newInputWidth);
-    };
-
-    useEffect(() => updateInputWidth(), [AutosizeInputState.value]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [AutosizeInputState.value]);
 
     const HiddenText = styled.span`
         position: absolute;
@@ -70,12 +69,14 @@ const BaseInput = (props: AutosizeInputProps): React.ReactElement<AutosizeInputP
     return (
         <div className={className}>
             <input
-                onChange={(e) => resizeInput(e)}
+                onChange={(e) => {
+                    onChange(e);
+                    resizeInput(e);
+                }}
                 style={dynamicStyle}
                 value={AutosizeInputState.value}
                 placeholder={placeholder}
                 {...other}
-                autoFocus
             />
             <HiddenText ref={(ref) => { sizerEle = ref; }}>
                 {AutosizeInputState.value}
@@ -122,6 +123,7 @@ BaseInput.defaultProps = {
     type: 'text',
     minWidth: 1,
     maxLength: 17,
+    autoFocus: true,
     onChange: () => {},
 };
 

--- a/src/components/iconButton/index.tsx
+++ b/src/components/iconButton/index.tsx
@@ -32,11 +32,10 @@ const IconButton = (props: IconButtonProps): React.ReactElement<IconButtonProps>
     }
     const StyleButton = styled(Button)`
         align-items: center;
-        display: flex;
         .label_wrapp {
             width: 100%;
             justify-content: inherit;
-            display: inherit;
+            display: flex;
             align-items: inherit;
             position: relative;
             .ic_wrapp {
@@ -49,7 +48,6 @@ const IconButton = (props: IconButtonProps): React.ReactElement<IconButtonProps>
         }
         ${!children && !btnInnerIc && css`
             min-width: auto !important;
-            padding: 12px !important;
         `}
     `;
 

--- a/src/hooks/useAutosizeInput.tsx
+++ b/src/hooks/useAutosizeInput.tsx
@@ -1,0 +1,18 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../modules';
+import { useCallback } from 'react';
+import { changeValue, changeWidth } from '../modules/autosizeInput';
+
+export default function useAutosizeInput() {
+  const AutosizeInputState = useSelector((state: RootState) => state.autosizeInput);
+  const dispatch = useDispatch();
+
+  const onChangeValue = useCallback((value) => dispatch(changeValue(value)), [dispatch]);
+  const onChangeWidth = useCallback((width) => dispatch(changeWidth(width)), [dispatch]);
+
+  return {
+    AutosizeInputState,
+    onChangeValue,
+    onChangeWidth,
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,12 +5,25 @@ import Root from './routes/index';
 import * as serviceWorker from './serviceWorker';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './static/theme';
+import { Provider } from 'react-redux';
+import { createStore, compose } from 'redux';
+import rootReducer from './modules';
+
+declare global {
+  interface Window {
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
+  }
+}
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(rootReducer, composeEnhancers());
 
 ReactDOM.render(
+  <Provider store={store}>
     <ThemeProvider theme={theme}>
-        <Root />
+      <Root />
     </ThemeProvider>
-, document.getElementById('root'));
+  </Provider>, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/modules/autosizeInput/actions.ts
+++ b/src/modules/autosizeInput/actions.ts
@@ -1,0 +1,9 @@
+import { createAction } from 'typesafe-actions';
+
+// 액션 type
+export const CHANGE_VALUE = 'autosizeInput/CHANGE_VALUE';
+export const CHANGE_WIDTH = 'autosizeInput/CHANGE_WIDTH';
+
+// 액션 생성 함수
+export const changeValue = createAction(CHANGE_VALUE)<string>();
+export const changeWidth = createAction(CHANGE_WIDTH)<number>();

--- a/src/modules/autosizeInput/index.ts
+++ b/src/modules/autosizeInput/index.ts
@@ -1,0 +1,3 @@
+export { default } from './reducer'; // reducer 를 불러와서 default로 내보내겠다는 의미
+export * from './actions'; // 모든 액션 생성함수들을 불러와서 같은 이름들로 내보내겠다는 의미
+export * from './types'; // 모든 타입들을 불러와서 같은 이름들로 내보내겠다는 의미

--- a/src/modules/autosizeInput/reducer.ts
+++ b/src/modules/autosizeInput/reducer.ts
@@ -1,0 +1,25 @@
+import { AutosizeInputState, AutosizeInputAction } from './types';
+import { createReducer } from 'typesafe-actions';
+import { CHANGE_VALUE, CHANGE_WIDTH } from './actions';
+
+const initialState: AutosizeInputState = {
+  value: '',
+  inputWidth: 1,
+};
+
+const AutosizeInput = createReducer<AutosizeInputState, AutosizeInputAction>(initialState, {
+  [CHANGE_VALUE]: (state, action) => {
+    return {
+      ...state,
+      value: action.payload,
+    };
+  },
+  [CHANGE_WIDTH]: (state, action) => {
+    return {
+      ...state,
+      inputWidth: action.payload,
+    };
+  },
+});
+
+export default AutosizeInput;

--- a/src/modules/autosizeInput/types.ts
+++ b/src/modules/autosizeInput/types.ts
@@ -1,0 +1,11 @@
+import { ActionType } from 'typesafe-actions';
+import * as actions from './actions';
+
+export type AutosizeInputAction = ActionType<typeof actions>;
+
+export interface AutosizeInput {
+  value: string;
+  inputWidth: number;
+}
+
+export type AutosizeInputState = AutosizeInput;

--- a/src/modules/autosizeInput/types.ts
+++ b/src/modules/autosizeInput/types.ts
@@ -3,9 +3,7 @@ import * as actions from './actions';
 
 export type AutosizeInputAction = ActionType<typeof actions>;
 
-export interface AutosizeInput {
+export interface AutosizeInputState {
   value: string;
   inputWidth: number;
 }
-
-export type AutosizeInputState = AutosizeInput;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,10 @@
+import { combineReducers } from 'redux';
+import autosizeInput from './autosizeInput';
+
+const rootReducer = combineReducers({
+  autosizeInput,
+});
+
+export default rootReducer;
+
+export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
input에 글자를 입력하면 입력한 글자 수에 따라서 width가 늘어났다가 작아졌다하는 컴포넌트입니다.
AutosizeInput은 input에 대한 컴포넌트이고, AutosizeButton은 AutosizeInput을 활용한 button 모양의 컴포넌트입니다.
width는 redux를 활용해서 변경합니다.

minWidth : 최소 길이를 정할 수 있고 만약 설정하지 않는다면 길이는 1
placeholder: minWidth를 설정하지 않고 placeholder를 설정한다면 처음 width는 placeholder width만큼 입니다.
maxLength: 최대 글자 길이입니다.

onChange, onBlur, onKeyDown 이벤트를 설정할 수 있습니다.
  
AutosizeButton에서 onCancle 속성은 x아이콘을 클릭했을 때 이벤트입니다.
![화면-기록-2020-04-17-오전-3 59 37](https://user-images.githubusercontent.com/26711037/79495936-56d16280-8060-11ea-96f8-4ae0741e3902.gif)
